### PR TITLE
Fixes missing var_itemsize for grid = 2.

### DIFF
--- a/src/bmi_prms_soil.f90
+++ b/src/bmi_prms_soil.f90
@@ -452,10 +452,10 @@
         bmi_status = BMI_SUCCESS
     case(2)
         type = 'scalar'
-        bmi_status = BMI_FAILURE
+        bmi_status = BMI_SUCCESS
     case(3)
         type = 'vector'
-        bmi_status = BMI_FAILURE
+        bmi_status = BMI_SUCCESS
     case default
         type = "-"
         bmi_status = BMI_FAILURE

--- a/src/bmi_prms_soil.f90
+++ b/src/bmi_prms_soil.f90
@@ -669,7 +669,7 @@
       integer :: bmi_status
 
       select case(grid)
-      case (0:3)
+      case(0:3)
          bmi_status = this%get_grid_node_count(grid, count)
          count = count - 1
       case default
@@ -686,7 +686,7 @@
       integer :: bmi_status
 
       select case(grid)
-      case (0:3)
+      case(0:3)
          count = 0
          bmi_status = BMI_SUCCESS
       case default

--- a/src/bmi_prms_soil.f90
+++ b/src/bmi_prms_soil.f90
@@ -1066,7 +1066,12 @@
             size = -1
             bmi_status = BMI_FAILURE
         endif
-
+    case('last_soil_moist')
+        size = sizeof(this%model%model_simulation%soil%last_soil_moist)
+        bmi_status = BMI_SUCCESS
+    case('last_ssstor')
+        size = sizeof(this%model%model_simulation%soil%last_ssstor)
+        bmi_status = BMI_SUCCESS
     case default
         size = -1
         bmi_status = BMI_FAILURE


### PR DESCRIPTION
@mdpiper sorry mark it was still failing on initialize.  I ran pymt_prms_soil_ex.py do try and figure out why PRMSSoil was failing on the initialize.  I discoverted that it was failing on bmi.grid_type when grid_id = 2. Two variables with grid_id = 2 had missing var_itemsize methods I assume that was the error.  these two variables have grid_id, type, size, get_value functions but not units, I assume that is ok.  Also I hacked the code to get past where this failed on method dataset_from_bmi_grid by adding if grid_id < 2: and the script ran to completion so I hop that I've solved the error.  

PS not sure why the first set of travis runs fails but the second completes.