### PR TITLE
Make output directory for tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,3 +54,4 @@ make_test(test_set_value_at_indices)
 file(
   COPY ${CMAKE_SOURCE_DIR}/projects/pipestem_soil/
   DESTINATION ${CMAKE_BINARY_DIR}/tests)
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tests/output)


### PR DESCRIPTION
This tiny PR ensures that the `output` directory specified in the PRMS control file is present when tests are run. If the directory isn't present, PRMS exits with 0 (success), so the tests automatically pass.